### PR TITLE
Fix HtmlWebpackPlugin error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "color-picker",
+  "version": "1.0.0",
+  "description": "A color picker application",
+  "main": "backend/server.js",
+  "scripts": {
+    "start": "node backend/server.js",
+    "build": "webpack --config webpack.config.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "mongoose": "^5.10.9",
+    "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
+    "html-webpack-plugin": "^5.3.2"
+  },
+  "devDependencies": {
+    "webpack": "^5.24.2",
+    "webpack-cli": "^4.5.0",
+    "babel-loader": "^8.2.2",
+    "style-loader": "^2.0.0",
+    "css-loader": "^5.1.1"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './frontend/app.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './frontend/index.html',
+    }),
+  ],
+  devServer: {
+    contentBase: path.join(__dirname, 'dist'),
+    compress: true,
+    port: 9000,
+  },
+};


### PR DESCRIPTION
Add webpack configuration and dependencies for HTML Webpack Plugin.

* **webpack.config.js**
  - Add `HtmlWebpackPlugin` import at the top of the file.
  - Add `HtmlWebpackPlugin` configuration in the `plugins` array.
* **package.json**
  - Add `html-webpack-plugin` to the `dependencies` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/color-picker/pull/2?shareId=53641aef-f369-4d73-a6d3-8edbfd923e62).